### PR TITLE
Fix linux compilation errors

### DIFF
--- a/macos/SheenBidi/Source/SBBase.c
+++ b/macos/SheenBidi/Source/SBBase.c
@@ -78,6 +78,7 @@ SB_INTERNAL void SBUIntegerNormalizeRange(SBUInteger actualLength,
     }
 }
 
+#ifdef DEBUG
 SB_INTERNAL SBBoolean SBUIntegerVerifyRange(SBUInteger actualLength,
     SBUInteger rangeOffset, SBUInteger rangeLength)
 {
@@ -87,6 +88,7 @@ SB_INTERNAL SBBoolean SBUIntegerVerifyRange(SBUInteger actualLength,
         && rangeOffset <= possibleLimit
         && possibleLimit <= actualLength;
 }
+#endif
 
 SBBidiType SBCodepointGetBidiType(SBCodepoint codepoint)
 {

--- a/macos/SheenBidi/Source/SBBase.h
+++ b/macos/SheenBidi/Source/SBBase.h
@@ -32,9 +32,10 @@
 SB_INTERNAL void SBUIntegerNormalizeRange(SBUInteger actualLength,
     SBUInteger *rangeOffset, SBUInteger *rangeLength);
 
+#ifdef DEBUG
 SB_INTERNAL SBBoolean SBUIntegerVerifyRange(SBUInteger actualLength,
     SBUInteger rangeOffset, SBUInteger rangeLength);
-
+#endif
 
 #define SBNumberGetMax(first, second)           \
 (                                               \

--- a/macos/SheenBidi/Source/SBParagraph.c
+++ b/macos/SheenBidi/Source/SBParagraph.c
@@ -614,14 +614,12 @@ static SBBoolean ResolveParagraph(SBParagraphRef paragraph,
 SB_INTERNAL SBParagraphRef SBParagraphCreate(SBAlgorithmRef algorithm,
     SBUInteger paragraphOffset, SBUInteger suggestedLength, SBLevel baseLevel)
 {
-    const SBCodepointSequence *codepointSequence = &algorithm->codepointSequence;
-    SBUInteger stringLength = codepointSequence->stringLength;
     SBUInteger actualLength;
 
     SBParagraphRef paragraph;
 
     /* The given range MUST be valid. */
-    SBAssert(SBUIntegerVerifyRange(stringLength, paragraphOffset, suggestedLength) && suggestedLength > 0);
+    SBAssert(SBUIntegerVerifyRange(&algorithm->codepointSequence->stringLength, paragraphOffset, suggestedLength) && suggestedLength > 0);
 
     SB_LOG_BLOCK_OPENER("Paragraph Input");
     SB_LOG_STATEMENT("Paragraph Offset", 1, SB_LOG_NUMBER(paragraphOffset));


### PR DESCRIPTION
It seems that sometime the option to turn warnings into errors was turned on
Some functions are only used by asserts so in release they become unused functions.

This fixes compilation on Ubuntu 24.04
